### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Jekyll requires Ruby so make sure Ruby is installed before you begin.
 - Install Jekyll and Bundler
   - `gem install jekyll bundler`
 - Create a New Site
-  - `jekyl new mysite`
+  - `jekyll new mysite`
 - Move into that directory
   - `cd mysite`
 - Verify
@@ -26,7 +26,7 @@ Jekyll requires Ruby so make sure Ruby is installed before you begin.
 
 
 ### Migrate an Existing Site
-**NOTE** This requires you to be upgraded to at least Jekyll 3.3 which added support for themes and assets.
+**NOTE** This requires you to be upgraded to at least Jekyll 3.2 which added support for themes and assets.
 
 - Download Overkyll Theme
   - Replace the line `gem "minima"` with this:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Jekyll requires Ruby so make sure Ruby is installed before you begin.
 
 
 ### Migrate an Existing Site
-**NOTE** This requires you to be upgraded to at least Jekyll 3.2 which added support for themes and assets.
+**NOTE** This requires you to be upgraded to at least Jekyll 3.3 which added support for themes and assets.
 
 - Download Overkyll Theme
   - Replace the line `gem "minima"` with this:


### PR DESCRIPTION
Hello! 

Fixed a typo for the command line operations ~~and the Jekyll version that began supporting themes (3.2, not 3.3).~~