### PR TITLE
Rely on Jekyll's default configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,9 +23,3 @@ baseurl: "/overkyll-jekyll-theme" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site
 twitter_username: bertrandkeller
 github_username:  bertrandkeller
-
-# Build settings
-markdown: kramdown
-
-exclude:
-  - Gemfile.lock


### PR DESCRIPTION
kramdown and exluded files are already set in default configuration:

https://github.com/jekyll/jekyll/blob/master/lib/jekyll/configuration.rb#L22-L42